### PR TITLE
Issue #40: Prevent PHP notices when optional core modules not enabled.

### DIFF
--- a/reference.module
+++ b/reference.module
@@ -8,19 +8,23 @@
 /**
  * Implements hook_entity_info_alter().
  *
- * TO DO: Patch core entities to have each provide its own values.
+ * @todo: Patch core entities to have each provide its own values.
  * https://github.com/backdrop/backdrop-issues/issues/3103
  */
 function reference_entity_info_alter(&$entity_info) {
-  $entity_info['comment']['entity keys']['label'] = 'subject';
-  $entity_info['comment']['entity keys']['status'] = 'status';
   $entity_info['file']['entity keys']['label'] = 'filename';
   $entity_info['file']['entity keys']['status'] = 'status';
   $entity_info['node']['entity keys']['label'] = 'title';
   $entity_info['node']['entity keys']['status'] = 'status';
-  $entity_info['taxonomy_term']['entity keys']['label'] = 'name';
   $entity_info['user']['entity keys']['label'] = 'name';
   $entity_info['user']['entity keys']['status'] = 'status';
+  if (module_exists('comment')) {
+    $entity_info['comment']['entity keys']['label'] = 'subject';
+    $entity_info['comment']['entity keys']['status'] = 'status';
+  }
+  if (module_exists('taxonomy')) {
+    $entity_info['taxonomy_term']['entity keys']['label'] = 'name';
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/reference/issues/40